### PR TITLE
Fix: Unify submissions review to show both legacy and workflow submissions

### DIFF
--- a/app/api/admin/submissions/route.ts
+++ b/app/api/admin/submissions/route.ts
@@ -3,11 +3,12 @@ import { sql } from '@/lib/db'
 
 export async function GET() {
   try {
-    // Get all submissions ordered by creation date (newest first)
-    const submissions = await sql`
+    // Get legacy tool submissions
+    const legacySubmissions = await sql`
       SELECT 
+        'legacy' as submission_type,
         id,
-        tool_name,
+        tool_name as title,
         website_url,
         category,
         description,
@@ -17,12 +18,44 @@ export async function GET() {
         additional_info,
         status,
         created_at,
-        updated_at
+        updated_at,
+        NULL as workflow_type,
+        NULL as content,
+        NULL as tools_used,
+        NULL as github_url,
+        NULL as reviewer_notes
       FROM submissions 
-      ORDER BY created_at DESC
     `
 
-    return NextResponse.json(submissions)
+    // Get workflow submissions  
+    const workflowSubmissions = await sql`
+      SELECT 
+        'workflow' as submission_type,
+        id,
+        title,
+        NULL as website_url,
+        workflow_type as category,
+        description,
+        'Workflow submission' as why_review,
+        NULL as your_role,
+        submitter_email as email,
+        content as additional_info,
+        status,
+        created_at,
+        updated_at,
+        workflow_type,
+        content,
+        tools_used,
+        github_url,
+        reviewer_notes
+      FROM workflow_submissions
+    `
+
+    // Combine and sort by creation date
+    const allSubmissions = [...legacySubmissions, ...workflowSubmissions]
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+
+    return NextResponse.json(allSubmissions)
   } catch (error) {
     console.error('Error fetching submissions for admin:', error)
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- Fixes the issue where admin submissions review page only showed legacy tool submissions
- Admin dashboard now correctly shows pending count (was 0, now shows 2)
- Unified interface to manage both legacy tool submissions and workflow submissions

## Changes Made
- **API Enhancement**: Updated `/api/admin/submissions` to return unified view from both tables
- **Enhanced PUT/DELETE endpoints** to handle both submission types with proper type discrimination
- **Updated UI** to display submission type badges, workflow-specific fields, and appropriate action buttons
- **Added 'approved' status** for workflow submissions alongside existing statuses

## Technical Details
- Combined data from `submissions` and `workflow_submissions` tables
- Enhanced TypeScript interfaces with `submission_type: 'legacy' | 'workflow'`
- Backward compatible with existing legacy submission workflow
- Proper status handling including 'reviewing' as pending in dashboard stats

## Test Plan
- [x] Admin dashboard shows correct pending count (2 submissions)
- [x] Submissions review page displays both types of submissions
- [x] Can update status for both legacy and workflow submissions
- [x] Can delete both types of submissions
- [x] Filter tabs work correctly with new 'approved' status
- [x] Build succeeds with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.ai/code)