### PR TITLE
Secure admin API endpoints

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,8 +7,9 @@ export default withAuth(
   {
     callbacks: {
       authorized: ({ token, req }) => {
-        // Only allow access to admin routes if user has admin role
-        if (req.nextUrl.pathname.startsWith('/admin')) {
+        const path = req.nextUrl.pathname
+        // Only allow access to admin routes and admin APIs if user has admin role
+        if (path.startsWith('/admin') || path.startsWith('/api/admin')) {
           return token?.role === 'admin'
         }
         return true
@@ -21,5 +22,5 @@ export default withAuth(
 )
 
 export const config = {
-  matcher: ['/admin/:path*']
+  matcher: ['/admin/:path*', '/api/admin/:path*']
 }


### PR DESCRIPTION
## Summary
- protect `/api/admin` routes via middleware
- enforce admin session checks on upload endpoint
- require admin permissions for submissions API
- add missing trailing newlines

## Testing
- `bun run dev`
- `bun run lint` *(fails: lint errors in repo)*
- `bun run build` *(fails: could not fetch fonts due to network issues)*

------
https://chatgpt.com/codex/tasks/task_b_6857777acc64832cb902cc179ae318a3